### PR TITLE
Fix script build_devkit

### DIFF
--- a/build_with_devkit.bat
+++ b/build_with_devkit.bat
@@ -23,6 +23,7 @@ rmdir build /Q /S
 mkdir build
 cd build
 cmake -Dpxr_DIR="%usd_build_fullpath%" -DMAYAUSD_OPENEXR_STATIC=ON -DPXR_USD_LOCATION="%usd_build_fullpath%" -DCMAKE_INSTALL_PREFIX="..\..\Build_RPRUsdInstall" -DCMAKE_GENERATOR="Visual Studio 15 2017 Win64" -DPYTHON_INCLUDE_DIR="%Python_Include_Dir%" -DPYTHON_EXECUTABLE="%Maya_x64%/bin/mayapy.exe" -DPYTHON_LIBRARIES="%Python_Library%" ..
+cmake -DOPENEXR_LOCATION="%MAYA_x64_2023%/../MayaUSD/Maya2023/0.18.0/mayausd/USD/" ..
 cmake --build . --config RelWithDebInfo --target install
 cd ../..
 


### PR DESCRIPTION
PURPOSE: build_devkit.bat script is not working with the latest develop because of changes made in RprUsd repo. This PR fixes this issue.

TECHNICAL DETAILS: In USD repo for ubuntu cmake was forced not to use default search path thus we need to set necessary paths manually. However setting OPENEXR_LOCATION instead of CMAKE_PREFIX_PATH fixed the issue