### PR TITLE
MAYAUS-191

### DIFF
--- a/RprUsd/src/ProductionRender/RprUsdProductionRender.cpp
+++ b/RprUsd/src/ProductionRender/RprUsdProductionRender.cpp
@@ -486,6 +486,9 @@ void RprUsdProductionRender::Initialize()
 	controlCreationCmds = ProductionSettings::CreateAttributes();
 
 	RprUsdProductionRender::RegisterRenderer(controlCreationCmds);
+
+    // in case if we start the plugin after scene is opened
+    ProductionSettings::UsdCameraListRefresh();
 }
 
 void RprUsdProductionRender::Uninitialize()

--- a/RprUsd/src/pluginMain.cpp
+++ b/RprUsd/src/pluginMain.cpp
@@ -19,7 +19,6 @@ PLUGIN_EXPORT MStatus initializePlugin(MObject obj)
 	CHECK_MSTATUS(status);
 	RprUsdProductionRenderCmd::Initialize();
 
-
     return ret;
 }
 


### PR DESCRIPTION
WHAT:
If load rprUSD plugin after scene is opened, usd camera list will be empty

WHY:
User should have Usd Camera List even if he loads a plugin after scene is opened

HOW:
We should call usd camera list refresh after the plugin is loaded.