### PR TITLE
MAYAUS-219: Fix for Render time statistics

### DIFF
--- a/RprUsd/src/ProductionRender/RprUsdProductionRender.cpp
+++ b/RprUsd/src/ProductionRender/RprUsdProductionRender.cpp
@@ -133,7 +133,7 @@ void RprUsdProductionRender::RPRMainThreadTimerEventCallback(float, float, void*
 	pProductionRender->ProcessTimerMessage();
 }
 
-void RprUsdProductionRender::ProcessTimerMessage()
+bool RprUsdProductionRender::ProcessTimerMessage()
 {
 	HdRenderDelegate* renderDelegate = _renderIndex->GetRenderDelegate();
 
@@ -156,7 +156,7 @@ void RprUsdProductionRender::ProcessTimerMessage()
 		}
 	}
 
-	RefreshAndCheck();
+	return RefreshAndCheck();
 }
 
 bool RprUsdProductionRender::RefreshAndCheck()
@@ -200,10 +200,7 @@ MStatus RprUsdProductionRender::StartRender(unsigned int width, unsigned int hei
 
 	MRenderView::startRender(width, height, false, true);
 
-	if (!synchronousRender)
-	{
-		_renderProgressBars = std::make_unique<RenderProgressBars>(false);
-	}
+	_renderProgressBars = std::make_unique<RenderProgressBars>(false);
 
 	ApplySettings();
 	Render();
@@ -229,7 +226,7 @@ void RprUsdProductionRender::ProcessSyncRender(float refreshRate)
 	{
 		std::chrono::duration<float, std::ratio<1>> time(refreshRate);
 		std::this_thread::sleep_for(time);
-	} while (RefreshAndCheck());
+	} while (ProcessTimerMessage());
 }
 
 void RprUsdProductionRender::ApplySettings()

--- a/RprUsd/src/ProductionRender/RprUsdProductionRender.h
+++ b/RprUsd/src/ProductionRender/RprUsdProductionRender.h
@@ -51,7 +51,7 @@ private:
 	bool RefreshAndCheck();
 
 	static void RPRMainThreadTimerEventCallback(float, float, void * pClientData);
-	void ProcessTimerMessage();
+	bool ProcessTimerMessage();
 
 	void ProcessSyncRender(float refreshRate);
 


### PR DESCRIPTION
WHAT:
First Iteration Time statistics does not show up if render was launched in synchronous mode (For auto tests)