### PR TITLE
Remove docking to fix UI issues

### DIFF
--- a/RprUsd/src/python/rprMaterialXBrowser.py
+++ b/RprUsd/src/python/rprMaterialXBrowser.py
@@ -134,7 +134,6 @@ class RPRMaterialBrowser(object) :
         # Initialize the layout.
         self.initializeLayout();
 
-        cmds.dockControl( "Radeon ProRender MaterialX Browser", content=self.window, fl=True, area="bottom")
     # Create the material categories layout.
     # -----------------------------------------------------------------------------
     def createCategoriesLayout(self) :


### PR DESCRIPTION
WHAT:
For Web MaterialX Window docking is removed 

WHY:
Dockable style introduces alot of issues within MatX browser UI

HOW:
Remove docking to fix the issue