### PR TITLE
Reorganize UI parameters for production render

### DIFF
--- a/RprUsd/RprUsd.vcxproj
+++ b/RprUsd/RprUsd.vcxproj
@@ -120,8 +120,8 @@ XCOPY /E /Y $(ProjectDir)\icons\* $(SolutionDir)dist\icons\
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <AdditionalIncludeDirectories>$(MAYA_SDK_2023)\include;$(MAYA_x64_2023)\..\MayaUSD\Maya2023\0.20.0\mayausd\USD\include\boost-1_70;$(MAYA_x64_2023)\..\MayaUSD\Maya2023\0.20.0\mayausd\USD\include;$(MAYA_x64_2023)\include\Python39\Python;$(ProjectDir)\src\ProductionRender;$(MAYA_SDK_2023)\devkit\ufe\include;$(MAYA_x64_2023)\..\MayaUSD\Maya2023\0.20.0\mayausd\MayaUSD\include\hdMaya;$(MAYA_x64_2023)\..\MayaUSD\Maya2023\0.20.0\mayausd\MayaUSD\include;$(MAYA_x64_2023)\..\MayaUSD\Maya2023\0.20.0\mayausd\MayaUSD\include\hdMaya\adapters;./../</AdditionalIncludeDirectories>
-      <Optimization>Disabled</Optimization>
-      <InlineFunctionExpansion>Disabled</InlineFunctionExpansion>
+      <Optimization>MaxSpeed</Optimization>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/RprUsd/src/ProductionRender/ProductionSettings.cpp
+++ b/RprUsd/src/ProductionRender/ProductionSettings.cpp
@@ -201,7 +201,7 @@ void _CreateStringAttribute(
     const MString&     attrName,
     const std::string& defValue,
     bool               useUserOptions,
-	bool               usedasFilename = false)
+    bool               usedasFilename = false)
 {
 
     const auto attr = node.attribute(attrName);
@@ -403,7 +403,7 @@ template <> void _GetFromPlug<TfEnum>(const MPlug& plug, TfEnum& out)
 
 template <> void _GetFromPlug<SdfAssetPath>(const MPlug& plug, SdfAssetPath& out)
 {
-	out = SdfAssetPath(std::string(plug.asString().asChar())); //  (out.GetType(), plug.asInt());
+	out = SdfAssetPath(std::string(plug.asString().asChar()));
 }
 
 template <> void _GetFromPlug<TfToken>(const MPlug& plug, TfToken& out)
@@ -606,7 +606,7 @@ void ProductionSettings::MakeAttributeLogicalStructure()
 	cameraTabDescPtr->groupVector.push_back(cameraMiscModeGroupPtr);
 }
 
-void ProductionSettings::CreateAttributes(std::map<std::string, std::string>& ctrlCreationForTabs)
+void ProductionSettings::CreateAttributes(std::map<std::string, std::string>* pMapCtrlCreationForTabs)
 {
 	std::string rendererName = GetRendererName();
 	HdRendererPlugin* rendererPlugin = HdRendererPluginRegistry::GetInstance().GetRendererPlugin(TfToken(rendererName));
@@ -783,7 +783,9 @@ void ProductionSettings::CreateAttributes(std::map<std::string, std::string>& ct
 			tabCtrlCreationCommands += "setParent ..;\n";
 		}
 
-		ctrlCreationForTabs[tabPtr->name] = tabCtrlCreationCommands;
+		if (pMapCtrlCreationForTabs) {
+			(*pMapCtrlCreationForTabs)[tabPtr->name] = tabCtrlCreationCommands; 
+		}
 	}
 }
 
@@ -802,7 +804,6 @@ void ProductionSettings::ApplySettings(HdRenderDelegate* renderDelegate)
 
 	bool storeUserSetting = false;
 
-//	for (const HdRenderSettingDescriptor& attr : rendererSettingDescriptors) {
 	for (TabDescriptionPtr tabPtr : _tabsLogicalStructure) {
 		for (GroupDescriptionPtr groupPtr : tabPtr->groupVector) {
 			for (AttributeDescriptionPtr attrPtr : groupPtr->attributeVector) {
@@ -881,8 +882,7 @@ void ProductionSettings::ApplySettings(HdRenderDelegate* renderDelegate)
 
 void ProductionSettings::CheckRenderGlobals()
 {
-	std::map<std::string, std::string> map;
-	CreateAttributes(map);
+	CreateAttributes();
 }
 
 void ProductionSettings::ClearUsdCameraAttributes()

--- a/RprUsd/src/ProductionRender/ProductionSettings.h
+++ b/RprUsd/src/ProductionRender/ProductionSettings.h
@@ -37,15 +37,6 @@ PXR_NAMESPACE_OPEN_SCOPE
 
 
 // Logical structure of attributes - Tabs and Groups
-/*struct AttributeDescription
-{
-	AttributeDescription(const std::string& attrSchemaName, const std::string& attrlabel) :
-		schemaAttrbiuteName(attrSchemaName)
-		, label(attrlabel) {}
-
-	std::string schemaAttrbiuteName;
-	std::string label;
-};*/
 
 typedef std::shared_ptr<HdRenderSettingDescriptor> AttributeDescriptionPtr;
 
@@ -77,7 +68,7 @@ public:
     ~ProductionSettings() = default;
  
     // Creating render globals attributes on "defaultRenderGlobals"
-	static void CreateAttributes(std::map<std::string, std::string>& ctrlCreationForTabs);
+	static void CreateAttributes(std::map<std::string, std::string>* pMapCtrlCreationForTabs = nullptr);
 	static void ClearUsdCameraAttributes();
 	static void ApplySettings(HdRenderDelegate* renderDelegate);
 

--- a/RprUsd/src/ProductionRender/RprUsdProductionRender.cpp
+++ b/RprUsd/src/ProductionRender/RprUsdProductionRender.cpp
@@ -557,7 +557,7 @@ void RprUsdProductionRender::Initialize()
 	std::map<std::string, std::string> controlCreationCmds;
 
 	ProductionSettings::RegisterCallbacks();
-	ProductionSettings::CreateAttributes(controlCreationCmds);
+	ProductionSettings::CreateAttributes(&controlCreationCmds);
 
 	RprUsdProductionRender::RegisterRenderer(controlCreationCmds);
 


### PR DESCRIPTION
WHAT:
We organize UI parameters better by splitting them into tabs and groups

WHY:
Its more convenient for a user

HOW:
We define new logical structure in the code by making structures.
Then we create maya's attributes by using this information