### PR TITLE
Add button for refreshing usd camera list

### DIFF
--- a/RprUsd/src/ProductionRender/RprUsdProductionRender.cpp
+++ b/RprUsd/src/ProductionRender/RprUsdProductionRender.cpp
@@ -683,22 +683,40 @@ void RprUsdProductionRender::RegisterRenderer(const std::map<std::string, std::s
 
 		frameLayout - label "Usd Camera" - cll true - cl false;
 
-		attrControlGrp -label "Enable USD Camera" -attribute "defaultRenderGlobals.HdRprPlugin_Prod_Static_useUSDCamera" -changeCommand "OnIsUseUsdCameraChanged";
-		$g_rprHdrUSDCamerasCtrl = `optionMenu -l "USD Camera: " -changeCommand "OnUsdCameraChanged"`;
-		setParent ..;
+			columnLayout  -adjustableColumn false;
 
-		for ($i = 0; $i < size($usdCamerasArray); $i++) 
-		{
-			$cameraName = $usdCamerasArray[$i];
-			menuItem -parent $g_rprHdrUSDCamerasCtrl -label $cameraName;
-		}
+				columnLayout  -adjustableColumn false -co "left" 140;
+					button -label "Refresh USD Camera List" -width 160 -command "OnUSDCameraListRefresh";
+				setParent ..;
 
-		$value = GetCameraSelectedAttribute();
-		if ($value != "")
-		{
-			optionMenu -e -v $value $g_rprHdrUSDCamerasCtrl; 
-		}
-		setParent ..;
+				attrControlGrp -label "Enable USD Camera" -attribute "defaultRenderGlobals.HdRprPlugin_Prod_Static_useUSDCamera" -changeCommand "OnIsUseUsdCameraChanged";
+
+				columnLayout  -adjustableColumn false -co "left" 140;
+					$g_rprHdrUSDCamerasCtrl = `optionMenu -l "USD Camera: " -changeCommand "OnUsdCameraChanged"`;
+					setParent ..;
+				setParent ..;
+
+				$value = GetCameraSelectedAttribute();
+
+				$valueExist = 0;
+				for ($i = 0; $i < size($usdCamerasArray); $i++) 
+				{
+					$cameraName = $usdCamerasArray[$i];
+					menuItem -parent $g_rprHdrUSDCamerasCtrl -label $cameraName;
+
+					if ($cameraName == $value)
+					{
+						$valueExist = 1;
+					}
+				}
+
+				if ($value != "" && $valueExist > 0)
+				{
+					optionMenu -e -v $value $g_rprHdrUSDCamerasCtrl; 
+				}
+			setParent ..; // columnLayout
+
+		setParent ..; // frameLayout
 
 		{CAMERA_CONTROLS_CREATION_CMDS}
 
@@ -727,6 +745,11 @@ void RprUsdProductionRender::RegisterRenderer(const std::map<std::string, std::s
 
 		$enabled = `getAttr defaultRenderGlobals.HdRprPlugin_Prod_Static_useUSDCamera`;
 		optionMenu -e -en $enabled $g_rprHdrUSDCamerasCtrl;
+	}
+
+	global proc OnUSDCameraListRefresh()
+	{
+		rprUsdRender -ucr;
 	}
 
 	global proc updateRprUsdRenderCameraTab()

--- a/RprUsd/src/ProductionRender/RprUsdProductionRenderCmd.cpp
+++ b/RprUsd/src/ProductionRender/RprUsdProductionRenderCmd.cpp
@@ -1,6 +1,7 @@
 
 #include "RprUsdProductionRenderCmd.h"
 #include "RprUsdProductionRender.h"
+#include "ProductionSettings.h"
 
 #include "maya/MGlobal.h"
 #include "maya/MDagPath.h"
@@ -65,6 +66,8 @@ MSyntax RprUsdProductionRenderCmd::newSyntax()
 
 	CHECK_MSTATUS(syntax.addFlag(kWaitForItTwoStep, kWaitForItTwoStepLong, MSyntax::kNoArg));
 
+	CHECK_MSTATUS(syntax.addFlag(kUSDCameraListRefreshFlag, kUSDCameraListRefreshFlagLong, MSyntax::kNoArg));
+
 	return syntax;
 }
 
@@ -122,6 +125,11 @@ MStatus RprUsdProductionRenderCmd::doIt(const MArgList & args)
 {
 	// Parse arguments.
 	MArgDatabase argData(syntax(), args);
+
+	if (argData.isFlagSet(kUSDCameraListRefreshFlag) || argData.isFlagSet(kUSDCameraListRefreshFlagLong)) {
+		ProductionSettings::UsdCameraListRefresh();
+		return MStatus::kSuccess;
+	}
 
 	if (argData.isFlagSet(kWaitForItTwoStep) || argData.isFlagSet(kWaitForItTwoStepLong)) {
 		s_waitForIt = true;

--- a/RprUsd/src/ProductionRender/RprUsdProductionRenderCmd.h
+++ b/RprUsd/src/ProductionRender/RprUsdProductionRenderCmd.h
@@ -21,6 +21,10 @@
 #define kWaitForItTwoStep "-wft"
 #define kWaitForItTwoStepLong "-waitForItTwo"
 
+// Misc flag. Its not related to rendering itself
+#define kUSDCameraListRefreshFlag "-ucr"
+#define kUSDCameraListRefreshFlagLong "-usdCameraListRefresh"
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 class RprUsdProductionRender;


### PR DESCRIPTION
WHAT:
In some scenarios user should be able to refresh usd camera list. Currently this list gets updated only upon scene open

HOW:
We added a button to let user do this.