### PR TITLE
Setup scene delegate properly. temporary hack

### DIFF
--- a/RprUsd/src/ProductionRender/RprUsdProductionRender.cpp
+++ b/RprUsd/src/ProductionRender/RprUsdProductionRender.cpp
@@ -418,6 +418,7 @@ bool RprUsdProductionRender::InitHydraResources()
 
 					// Temporary Hack! We access private variable here because we cannot modify MtoH directly.
 					// I want to contribute setter method for this variable in MtoH. If they approve we will remove the hack.
+					// We are accessing privte variable HdMayaSceneDelegate::_enableMaterials here
 					unsigned int classAlignment = alignof(HdMayaSceneDelegate);
 					char* adr = ((char*)pMayaSceneDelegate) + sizeof(HdMayaSceneDelegate) - sizeof(bool);
 					long offset = (long)adr % classAlignment;


### PR DESCRIPTION
WHAT:
Some standard materials does not work from production render on non usd stages(like in maya scenes without usd shape)

HOW:
We needs to set enableMaterials variable of HdMayaSceneDelegate to true.
Since there is no setter, I applied temporary hack and going to contribute necessary functionality to MtoH.

UPD. I made a PR into MtoH to remove the hack later
https://github.com/Autodesk/maya-usd/pull/2938