### PR TITLE
Remove units conversion calls

### DIFF
--- a/RprUsd/src/ProductionRender/RprUsdProductionRender.cpp
+++ b/RprUsd/src/ProductionRender/RprUsdProductionRender.cpp
@@ -355,11 +355,6 @@ bool RprUsdProductionRender::InitHydraResources()
 	if (!renderDelegate)
 		return false;
 
-    // set "metersPerUnit" setting. It can be used by render delegate to produce physically correct images
-    // for now unit size is always equal maya internal unit
-    static const TfToken metersPerUnitToken("stageMetersPerUnit", TfToken::Immortal);
-    renderDelegate->SetRenderSetting(metersPerUnitToken, VtValue(MDistance(1.00, MDistance::internalUnit()).asMeters()));
-
 	_renderIndex = HdRenderIndex::New(renderDelegate, { &_hgiDriver });
 	if (!_renderIndex)
 		return false;


### PR DESCRIPTION
WHAT:
We need to remove unnecessary units conversion to match viewport hdrpr and production render.