### PR TITLE
MAYAUS-270: Add new flag for clearing all references

### DIFF
--- a/RprUsd/CMakeLists.txt
+++ b/RprUsd/CMakeLists.txt
@@ -188,6 +188,8 @@ set(ROOT_NAMESPACE RprUsd)
 set_target_properties(${PROJECT_NAME} PROPERTIES
     VS_GLOBAL_KEYWORD "Win32Proj"
     SUFFIX ".mll"
+
+    VS_DEBUGGER_COMMAND "$(MAYA_x64_2024)/bin/maya.exe"
 )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/RprUsd/src/BindMtlxCommand/RprUsdBindMtlxCmd.h
+++ b/RprUsd/src/BindMtlxCommand/RprUsdBindMtlxCmd.h
@@ -20,6 +20,11 @@
 #define kMaterialNameFlag "-mn"
 #define kMaterialNameFlagLong "-materialName"
 
+// clearAllReference
+#define kClearAllReferencesFlag "-car"
+#define kClearAllReferencesFlagLong "-clearAllReferences"
+
+
 PXR_NAMESPACE_OPEN_SCOPE
 
 class RprUsdProductionRender;


### PR DESCRIPTION
WHAT:
MAYAUS-270
We added new flag "-clearAllReferences" (or "-car" as a short flag)  for QA guys  to let them clear material on a mesh