### PR TITLE
Rs kit submodule change

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = git@github.com:GPUOpen-LibrariesAndSDKs/RadeonProRenderUSD.git
 [submodule "RprUsd/RenderStudioResolver"]
 	path = RprUsd/RenderStudioResolver
-	url = git@github.com:Radeon-Pro/RenderStudioKit.git
+	url = git@github.com:GPUOpen-LibrariesAndSDKs/RenderStudioKit.git


### PR DESCRIPTION
WHAT:
Submodule link was changed to point to https://github.com/GPUOpen-LibrariesAndSDKs/RenderStudioKit repository